### PR TITLE
CRE-2461: switch GHA runner to self-hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, jimdo-runner-1core ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
The new self-hosted GHA runner is used in the CI GitHub Action workflow.